### PR TITLE
Fix markdown to retain list numbering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,11 @@ system, install in `/usr/local/libexec/nagios`.
 Configuration:
 
 1. Copy these files to /usr/lib/nagios/plugins:
-
    * `check_git`
    * `check_git_exec_ssh.sh`
-
 2. Configure a check command like
-
    * `$USER1$/check_git $ARG1$`
    * `$USER1$/check_git $ARG1$ --keyfile $ARG2$ --push`
-
 3. (optional) Create a keyfile that can be used as the SSH identity file:
 
         ssh-keygen -f /var/tmp/check_git_keyfile


### PR DESCRIPTION
The recent FreeBSD additions are very nice.  They fixed a bug in handling failures from git ls-remote as well.

Unfortunately, the changes also caused the README markdown to show a numbered list with 3 items, each numbered 1.  This deletes some blank lines so that the list is again numbered 1-5.
