### PR TITLE
make check_git work again with recent git

### DIFF
--- a/check_git
+++ b/check_git
@@ -151,7 +151,7 @@ if [ "$push" != "" ]; then
     ERROR=$(git commit -m "Test commit by check_git $NOW")
     OUTPUT="$OUTPUT
       $ERROR"
-    ERROR="$(git push 2>&1)"
+    ERROR="$(git push origin master:master 2>&1)"
     GIT_PUSH_RESULT=$?
     OUTPUT="$OUTPUT
      $ERROR"

--- a/check_git
+++ b/check_git
@@ -50,7 +50,12 @@ if [[ ! -d $REPO_DIR ]]; then
     echo "Could not create a temporary directory for the git repo; exiting"
     exit $STATE_UNKNOWN
 fi
-trap "rm -Rf $REPO_DIR" EXIT
+GIT_SSH=$(tempfile -d ~/.ssh --prefix git. --suffix .ssh -m 700)
+if [[ ! -x $GIT_SSH ]]; then
+    echo "Could not create a temporary git-ssh file; exiting"
+    exit $STATE_UNKNOWN
+fi
+trap "rm -Rf $REPO_DIR; rm -f $GIT_SSH" EXIT
 
 print_usage() {
     echo "Usage: $PROGNAME repo_url [ --keyfile /path/to/id_file ] [ --push ]"
@@ -92,9 +97,8 @@ while test -n "$1"; do
             keyfile=$2
             shift
 
-            echo "ssh -T -o StrictHostKeyChecking=no -i $keyfile \$*" > $REPO_DIR/.git-ssh
-            chmod 0700 $REPO_DIR/.git-ssh
-            export GIT_SSH=$REPO_DIR/.git-ssh
+            echo "ssh -T -o StrictHostKeyChecking=no -i $keyfile \$*" > $GIT_SSH
+            export GIT_SSH
             ;;
         --push)
             push=1

--- a/check_git
+++ b/check_git
@@ -149,7 +149,8 @@ if [ "$push" != "" ]; then
     export GIT_COMMITTER_NAME='check-git'
     export GIT_COMMITTER_EMAIL="`id -u -n`@$(hostname --long)"
     export GIT_AUTHOR_EMAIL="`id -u -n`@$(hostname --long)"
-    echo "Committed by Nagios on $(hostname) check_git: $(date)" >> $GIT_WORK_TREE/check_git_commits.txt
+
+    echo "Committed by Nagios on $(hostname) check_git: $(date)" >> $GIT_WORK_TREE/$(hostname).check_git_commits.txt
     git add .
     NOW=$(date)
     ERROR=$(git commit -m "Test commit by check_git $NOW")

--- a/check_git
+++ b/check_git
@@ -145,6 +145,10 @@ fi
 if [ "$push" != "" ]; then
     export GIT_WORK_TREE=$REPO_DIR
     export GIT_DIR=$REPO_DIR/.git
+    export GIT_AUTHOR_NAME='check-git'
+    export GIT_COMMITTER_NAME='check-git'
+    export GIT_COMMITTER_EMAIL="`id -u -n`@$(hostname --long)"
+    export GIT_AUTHOR_EMAIL="`id -u -n`@$(hostname --long)"
     echo "Committed by Nagios on $(hostname) check_git: $(date)" >> $GIT_WORK_TREE/check_git_commits.txt
     git add .
     NOW=$(date)

--- a/check_git_exec_ssh.sh
+++ b/check_git_exec_ssh.sh
@@ -3,7 +3,7 @@
 if [ "$IDENTITY_FILE" != "" ]; then
     IDFILE="-i$IDENTITY_FILE"
 fi
-CMD="ssh -oStrictHostKeyChecking=no $IDFILE"
+CMD="ssh -q -oStrictHostKeyChecking=no $IDFILE"
 exec $CMD "$@"
 
 # Copyright (c) 2011, 2012 Randy Fay and Mark Waite

--- a/icinga2.check_git.conf
+++ b/icinga2.check_git.conf
@@ -1,0 +1,28 @@
+object CheckCommand "check_git" {
+  import "plugin-check-command"
+
+  command = [ PluginDir + "/check_git" ]
+
+  arguments = {
+	"--keyfile" = {
+		value = "$check_git_ssh_keyfile$"
+		required = false
+	},
+	"--push" = {
+		description = "Test pushes to the repository"	
+		set_if = "$check_git_push$"
+		required = false
+	},
+	"--url" = {
+                # this is a positional parameter
+		skip_key = true
+		value = "$check_git_url$"
+		description = "URL to make git operations onto"	
+		required = true
+	},
+
+  }
+
+  vars.check_git_ssh_keyfile = "/var/lib/nagios/.ssh/id_rsa"
+  vars.check_git_push = false
+}


### PR DESCRIPTION
the push check always fails, cause git will not clone in a nonempty directory

plus git-2.0 changes:
* set a target branch
* use a separate file per check-client
* ignore issue.net that comes with a chatty sshd
* set a author/commiter
* add a configuration file for a icinga2 check-command

